### PR TITLE
Fix/google oauth

### DIFF
--- a/frontend/src/components/auth/LoginDialog.tsx
+++ b/frontend/src/components/auth/LoginDialog.tsx
@@ -21,7 +21,7 @@ export function LoginDialog({ open, onOpenChange, onSignUpClick }: LoginDialogPr
   const [password, setPassword] = useState("")
   const [error, setError] = useState("")
   const [isLoading, setIsLoading] = useState(false)
-  const { login } = useAuth()
+  const { login, loadUser } = useAuth()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -48,9 +48,17 @@ export function LoginDialog({ open, onOpenChange, onSignUpClick }: LoginDialogPr
 
   const handleGoogleSignIn = async () => {
     try {
+      setIsLoading(true);
       await apiService.googleAuth();
+      // Reload user after successful OAuth
+      await loadUser();
+      toast.success("Signed in with Google!");
+      onOpenChange(false);
     } catch (error) {
-      toast.error("Google sign in is not available in mock mode");
+      const errorMessage = error instanceof Error ? error.message : "Google sign in failed";
+      toast.error(errorMessage);
+    } finally {
+      setIsLoading(false);
     }
   }
 

--- a/frontend/src/components/auth/SignUpDialog.tsx
+++ b/frontend/src/components/auth/SignUpDialog.tsx
@@ -12,7 +12,7 @@ interface SignUpDialogProps {
 }
 
 export function SignUpDialog({ open, onOpenChange, onLoginClick }: SignUpDialogProps) {
-  const { signup } = useAuth();
+  const { signup, loadUser } = useAuth();
 
   const handleSuccess = useCallback(() => {
     toast.success("Account created successfully! Welcome to UniVoyage!");
@@ -49,10 +49,15 @@ export function SignUpDialog({ open, onOpenChange, onLoginClick }: SignUpDialogP
   const handleGoogleSignUp = useCallback(async () => {
     try {
       await apiService.googleAuth();
+      // Reload user after successful OAuth
+      await loadUser();
+      toast.success("Account created with Google!");
+      onOpenChange(false);
     } catch (error) {
-      toast.error("Google sign up is not available in mock mode");
+      const errorMessage = error instanceof Error ? error.message : "Google sign up failed";
+      toast.error(errorMessage);
     }
-  }, []);
+  }, [onOpenChange, loadUser]);
 
   const handleOpenChange = useCallback((newOpen: boolean) => {
     onOpenChange(newOpen);

--- a/frontend/src/pages/GoogleCallbackPage.tsx
+++ b/frontend/src/pages/GoogleCallbackPage.tsx
@@ -9,6 +9,7 @@ export default function GoogleCallbackPage() {
   const navigate = useNavigate()
   const { loadUser } = useAuth()
   const ran = useRef(false)
+  const isPopup = window.opener !== null
 
   useEffect(() => {
     if (ran.current) return
@@ -19,13 +20,33 @@ export default function GoogleCallbackPage() {
     const error = params.get("error")
 
     if (error) {
-      toast.error(`Google auth error: ${error}`)
-      navigate("/")
+      const errorMsg = `Google auth error: ${error}`
+      if (isPopup) {
+        // Send error to parent window
+        window.opener?.postMessage(
+          { type: 'GOOGLE_OAUTH_ERROR', error: errorMsg },
+          window.location.origin
+        )
+        window.close()
+      } else {
+        toast.error(errorMsg)
+        navigate("/")
+      }
       return
     }
+    
     if (!code) {
-      toast.error("Missing Google authorization code")
-      navigate("/")
+      const errorMsg = "Missing Google authorization code"
+      if (isPopup) {
+        window.opener?.postMessage(
+          { type: 'GOOGLE_OAUTH_ERROR', error: errorMsg },
+          window.location.origin
+        )
+        window.close()
+      } else {
+        toast.error(errorMsg)
+        navigate("/")
+      }
       return
     }
 
@@ -34,8 +55,17 @@ export default function GoogleCallbackPage() {
           const res = await apiService.googleCallback(code)
 
           if (!res.success) {
-              toast.error(res.error || "Google login failed")
-              navigate("/")
+              const errorMsg = res.error || "Google login failed"
+              if (isPopup) {
+                window.opener?.postMessage(
+                  { type: 'GOOGLE_OAUTH_ERROR', error: errorMsg },
+                  window.location.origin
+                )
+                window.close()
+              } else {
+                toast.error(errorMsg)
+                navigate("/")
+              }
               return
           }
 
@@ -45,14 +75,33 @@ export default function GoogleCallbackPage() {
           const redirectUrl = sessionStorage.getItem('google_oauth_redirect')
           sessionStorage.removeItem('google_oauth_redirect')
 
-          toast.success("Signed in with Google!")
-          navigate(redirectUrl || "/")
+          if (isPopup) {
+            // Send success to parent window
+            window.opener?.postMessage(
+              { type: 'GOOGLE_OAUTH_SUCCESS' },
+              window.location.origin
+            )
+            // Close popup immediately - parent will show success toast
+            window.close()
+          } else {
+            toast.success("Signed in with Google!")
+            navigate(redirectUrl || "/")
+          }
       } catch (e: any) {
-          toast.error(e?.message || "Google login failed")
-          navigate("/")
+          const errorMsg = e?.message || "Google login failed"
+          if (isPopup) {
+            window.opener?.postMessage(
+              { type: 'GOOGLE_OAUTH_ERROR', error: errorMsg },
+              window.location.origin
+            )
+            window.close()
+          } else {
+            toast.error(errorMsg)
+            navigate("/")
+          }
       }
     })()
-  }, [navigate, loadUser])
+  }, [navigate, loadUser, isPopup])
 
   return <div className="p-6">Signing you in with Google…</div>
 }

--- a/frontend/src/services/api/authApi.ts
+++ b/frontend/src/services/api/authApi.ts
@@ -148,7 +148,7 @@ export const authApi: { [K in keyof AuthApi]: (this: ApiClient, ...args: Paramet
       }
     },
 
-    async googleAuth(this: ApiClient) {
+    async googleAuth(this: ApiClient): Promise<void> {
       if (this.useMock) {
         throw new Error('Google auth not available in mock mode')
       }
@@ -157,7 +157,52 @@ export const authApi: { [K in keyof AuthApi]: (this: ApiClient, ...args: Paramet
       const currentUrl = window.location.pathname + window.location.search
       sessionStorage.setItem('google_oauth_redirect', currentUrl)
 
-      window.location.href = `${this.baseURL}${API_CONFIG.ENDPOINTS.AUTH.GOOGLE}`
+      // Open OAuth in a popup window
+      const width = 500
+      const height = 600
+      const left = window.screenX + (window.outerWidth - width) / 2
+      const top = window.screenY + (window.outerHeight - height) / 2
+
+      const popup = window.open(
+        `${this.baseURL}${API_CONFIG.ENDPOINTS.AUTH.GOOGLE}`,
+        'google-oauth',
+        `width=${width},height=${height},left=${left},top=${top},toolbar=no,menubar=no,scrollbars=yes,resizable=yes`
+      )
+
+      if (!popup) {
+        throw new Error('Popup blocked. Please allow popups for this site.')
+      }
+
+      // Listen for messages from the popup
+      return new Promise((resolve, reject) => {
+        const messageListener = (event: MessageEvent) => {
+          // Verify origin for security
+          if (event.origin !== window.location.origin) {
+            return
+          }
+
+          if (event.data.type === 'GOOGLE_OAUTH_SUCCESS') {
+            window.removeEventListener('message', messageListener)
+            popup.close()
+            resolve()
+          } else if (event.data.type === 'GOOGLE_OAUTH_ERROR') {
+            window.removeEventListener('message', messageListener)
+            popup.close()
+            reject(new Error(event.data.error || 'Google OAuth failed'))
+          }
+        }
+
+        window.addEventListener('message', messageListener)
+
+        // Check if popup is closed manually
+        const checkClosed = setInterval(() => {
+          if (popup.closed) {
+            clearInterval(checkClosed)
+            window.removeEventListener('message', messageListener)
+            reject(new Error('OAuth popup was closed'))
+          }
+        }, 500)
+      })
     },
 
     async googleCallback(this: ApiClient, code: string): Promise<AuthResponse<User>> {


### PR DESCRIPTION
- Fixed conflict of mandatory data when using OAuth
- Open Google OAuth in popup window instead of full page redirect
- Use postMessage API for communication between popup and parent window
- Update GoogleCallbackPage to handle both popup and direct redirect scenarios
- Store current page URL in sessionStorage for redirect after OAuth