### PR TITLE
Fix/menu bug where destinations drop menu shows on hover

### DIFF
--- a/frontend/src/components/ui/navigation-menu.tsx
+++ b/frontend/src/components/ui/navigation-menu.tsx
@@ -9,6 +9,7 @@ function NavigationMenu({
   className,
   children,
   viewport = true,
+  delayDuration = 999999,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
   viewport?: boolean
@@ -17,6 +18,7 @@ function NavigationMenu({
     <NavigationMenuPrimitive.Root
       data-slot="navigation-menu"
       data-viewport={viewport}
+      delayDuration={delayDuration}
       className={cn(
         "group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
         className


### PR DESCRIPTION
Fixed menu bug where destinations drop menu shows on hover.

On hover destinations drop menu doesn't show.

closes #133 