### PR TITLE
fix: add pointer cursor to all interactive elements (#134)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,21 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+/* Fix #134: pointer cursor on all interactive/clickable elements */
+button,
+[role="button"],
+a,
+select,
+label,
+input[type="checkbox"],
+input[type="radio"],
+input[type="submit"],
+input[type="reset"],
+summary,
+[tabindex]:not([tabindex="-1"]) {
+  cursor: pointer;
+}
+
 /* Any linter warnings for @custom-variant, @theme, @layer, and @apply are false positives. */
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
Closes #134

Added `cursor: pointer` globally in `index.css` for all interactive elements