### PR TITLE
Enhance security headers in SecurityConfiguration

### DIFF
--- a/backend/src/main/java/com/univoyage/config/SecurityConfiguration.java
+++ b/backend/src/main/java/com/univoyage/config/SecurityConfiguration.java
@@ -37,6 +37,10 @@ public class SecurityConfiguration {
                 .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .headers(headers -> headers
+                    .contentTypeOptions(Customizer.withDefaults())
+                    .frameOptions(frame -> frame.deny())
+)
                 .authorizeHttpRequests(auth -> auth
                         // Allow preflight CORS requests
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()


### PR DESCRIPTION
Added X-Content-Type-Options and X-Frame-Options security headers to all HTTP responses via Spring Security configuration. Added integration tests to verify headers are present on responses.
- closes #226 