### PR TITLE
fix/missing security headers #226

### DIFF
--- a/backend/src/test/java/com/univoyage/auth/controller/SecurityHeadersIntegrationTest.java
+++ b/backend/src/test/java/com/univoyage/auth/controller/SecurityHeadersIntegrationTest.java
@@ -1,0 +1,37 @@
+package com.univoyage.auth.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class SecurityHeadersIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Responses include X-Content-Type-Options: nosniff")
+    void contentTypeOptionsHeader() throws Exception {
+        mockMvc.perform(get("/api/auth/me"))
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"));
+    }
+
+    @Test
+    @DisplayName("Responses include X-Frame-Options: DENY")
+    void frameOptionsHeader() throws Exception {
+        mockMvc.perform(get("/api/auth/me"))
+                .andExpect(header().string("X-Frame-Options", "DENY"));
+    }
+}


### PR DESCRIPTION
Added X-Content-Type-Options and X-Frame-Options security headers to all HTTP responses via Spring Security configuration. Added integration tests to verify headers are present on responses.