### PR TITLE
feat(backend): implement contact form submission endpoint with rate limiting

### DIFF
--- a/backend/src/main/java/com/univoyage/auth/security/PublicApiRequestMatcher.java
+++ b/backend/src/main/java/com/univoyage/auth/security/PublicApiRequestMatcher.java
@@ -18,8 +18,8 @@ public class PublicApiRequestMatcher {
   private static final String[] PUBLIC_PATH_PATTERNS = {"/api/auth/login", "/api/auth/login/**",
       "/api/auth/register", "/api/auth/register/**", "/api/auth/refresh", "/api/auth/refresh/",
       "/api/auth/google/**", "/api/auth/github/**", "/api/auth/linkedin/**", "/api/auth/otp/**",
-      "/api/auth/password/**", "/api/auth/email/verification/**", "/api/quiz/**", "/error",
-      "/actuator/health", "/actuator/health/**"};
+      "/api/auth/password/**", "/api/auth/email/verification/**", "/api/quiz/**", "/api/contact",
+      "/error", "/actuator/health", "/actuator/health/**"};
 
   private static final String[] PUBLIC_GET_PATTERNS = {"/api/destinations/**", "/api/reference/**",
       "/api/heatmap/**"};

--- a/backend/src/main/java/com/univoyage/config/SecurityConfiguration.java
+++ b/backend/src/main/java/com/univoyage/config/SecurityConfiguration.java
@@ -62,6 +62,8 @@ public class SecurityConfiguration {
             .requestMatchers(HttpMethod.GET, "/api/reference/**").permitAll()
             // Public heatmap endpoint (landing page)
             .requestMatchers(HttpMethod.GET, "/api/heatmap/**").permitAll()
+            // Public contact form endpoint
+            .requestMatchers(HttpMethod.POST, "/api/contact").permitAll()
             // Admin 2FA endpoints (require authentication but not 2FA yet)
             .requestMatchers("/api/auth/2fa/**").hasAnyRole("ADMIN", "HEAD_ADMIN")
             // Admin routes (2FA enforced by AdminTwoFactorFilter)

--- a/backend/src/main/java/com/univoyage/contact/config/ContactLimitProperties.java
+++ b/backend/src/main/java/com/univoyage/contact/config/ContactLimitProperties.java
@@ -1,0 +1,17 @@
+package com.univoyage.contact.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "app.contact")
+@Getter
+@Setter
+public class ContactLimitProperties {
+
+  private int ipMaxAttempts = 5;
+
+  private Duration ipWindow = Duration.ofMinutes(15);
+}

--- a/backend/src/main/java/com/univoyage/contact/controller/ContactController.java
+++ b/backend/src/main/java/com/univoyage/contact/controller/ContactController.java
@@ -1,11 +1,15 @@
 package com.univoyage.contact.controller;
 
+import com.univoyage.auth.security.ClientIpResolver;
 import com.univoyage.common.response.ApiResponse;
 import com.univoyage.contact.dto.ContactRequest;
 import com.univoyage.contact.dto.ContactResponse;
+import com.univoyage.contact.security.ContactIpRateLimiter;
 import com.univoyage.contact.service.ContactService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,11 +21,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ContactController {
 
+  private static final String RATE_LIMIT_MSG = "Too many contact submissions. Please try again later.";
+
   private final ContactService contactService;
+  private final ContactIpRateLimiter contactIpRateLimiter;
 
   @PostMapping
   public ResponseEntity<ApiResponse<ContactResponse>> submitContactForm(
-      @Valid @RequestBody ContactRequest request) {
+      @Valid @RequestBody ContactRequest request, HttpServletRequest httpRequest) {
+    String ip = ClientIpResolver.resolve(httpRequest);
+    long retryAfterSec = contactIpRateLimiter.tryConsumeOrRetryAfterSeconds(ip);
+    if (retryAfterSec > 0) {
+      return ResponseEntity.status(429)
+          .header(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfterSec))
+          .body(ApiResponse.fail(RATE_LIMIT_MSG));
+    }
+
     ContactResponse response = contactService.submitContactForm(request);
     return ResponseEntity.ok(ApiResponse.ok(response));
   }

--- a/backend/src/main/java/com/univoyage/contact/controller/ContactController.java
+++ b/backend/src/main/java/com/univoyage/contact/controller/ContactController.java
@@ -1,0 +1,28 @@
+package com.univoyage.contact.controller;
+
+import com.univoyage.common.response.ApiResponse;
+import com.univoyage.contact.dto.ContactRequest;
+import com.univoyage.contact.dto.ContactResponse;
+import com.univoyage.contact.service.ContactService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/contact")
+@RequiredArgsConstructor
+public class ContactController {
+
+  private final ContactService contactService;
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<ContactResponse>> submitContactForm(
+      @Valid @RequestBody ContactRequest request) {
+    ContactResponse response = contactService.submitContactForm(request);
+    return ResponseEntity.ok(ApiResponse.ok(response));
+  }
+}

--- a/backend/src/main/java/com/univoyage/contact/dto/ContactRequest.java
+++ b/backend/src/main/java/com/univoyage/contact/dto/ContactRequest.java
@@ -1,0 +1,26 @@
+package com.univoyage.contact.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Value;
+
+@Value
+public class ContactRequest {
+
+  @NotBlank(message = "Name is required")
+  @Size(max = 100, message = "Name must be at most 100 characters")
+  String name;
+
+  @NotBlank(message = "Email is required")
+  @Email(message = "Must be a valid email address")
+  String email;
+
+  @NotBlank(message = "Subject is required")
+  @Size(max = 200, message = "Subject must be at most 200 characters")
+  String subject;
+
+  @NotBlank(message = "Message is required")
+  @Size(min = 10, max = 5000, message = "Message must be between 10 and 5000 characters")
+  String message;
+}

--- a/backend/src/main/java/com/univoyage/contact/dto/ContactResponse.java
+++ b/backend/src/main/java/com/univoyage/contact/dto/ContactResponse.java
@@ -1,0 +1,9 @@
+package com.univoyage.contact.dto;
+
+import lombok.Value;
+
+@Value
+public class ContactResponse {
+  String message;
+  String referenceId;
+}

--- a/backend/src/main/java/com/univoyage/contact/security/ContactIpRateLimiter.java
+++ b/backend/src/main/java/com/univoyage/contact/security/ContactIpRateLimiter.java
@@ -1,0 +1,22 @@
+package com.univoyage.contact.security;
+
+import com.univoyage.auth.security.FixedWindowIpRateLimiter;
+import com.univoyage.contact.config.ContactLimitProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+
+@Component
+public class ContactIpRateLimiter {
+
+  private final FixedWindowIpRateLimiter delegate;
+
+  public ContactIpRateLimiter(ContactLimitProperties properties, Clock clock) {
+    this.delegate = new FixedWindowIpRateLimiter(clock, properties.getIpMaxAttempts(),
+        properties.getIpWindow());
+  }
+
+  public long tryConsumeOrRetryAfterSeconds(String rawIp) {
+    return delegate.tryConsumeOrRetryAfterSeconds(rawIp);
+  }
+}

--- a/backend/src/main/java/com/univoyage/contact/service/ContactService.java
+++ b/backend/src/main/java/com/univoyage/contact/service/ContactService.java
@@ -1,0 +1,24 @@
+package com.univoyage.contact.service;
+
+import com.univoyage.contact.dto.ContactRequest;
+import com.univoyage.contact.dto.ContactResponse;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@Log4j2
+public class ContactService {
+
+  public ContactResponse submitContactForm(ContactRequest request) {
+    String referenceId = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+
+    log.info("Contact form submission [ref={}]: from={}, email={}, subject={}",
+        referenceId, request.getName(), request.getEmail(), request.getSubject());
+
+    return new ContactResponse(
+        "Thank you for reaching out! We'll get back to you within 24-48 hours.",
+        referenceId);
+  }
+}

--- a/backend/src/main/java/com/univoyage/contact/service/ContactService.java
+++ b/backend/src/main/java/com/univoyage/contact/service/ContactService.java
@@ -14,11 +14,10 @@ public class ContactService {
   public ContactResponse submitContactForm(ContactRequest request) {
     String referenceId = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
 
-    log.info("Contact form submission [ref={}]: from={}, email={}, subject={}",
-        referenceId, request.getName(), request.getEmail(), request.getSubject());
+    log.info("Contact form submission [ref={}]: from={}, email={}, subject={}", referenceId,
+        request.getName(), request.getEmail(), request.getSubject());
 
     return new ContactResponse(
-        "Thank you for reaching out! We'll get back to you within 24-48 hours.",
-        referenceId);
+        "Thank you for reaching out! We'll get back to you within 24-48 hours.", referenceId);
   }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -178,6 +178,10 @@ app:
       user-max-attempts: 30
       user-window: PT1M
 
+  contact:
+    ip-max-attempts: ${CONTACT_IP_MAX_ATTEMPTS:5}
+    ip-window: ${CONTACT_IP_WINDOW:PT15M}
+
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}
 

--- a/backend/src/test/java/com/univoyage/admin/user/controller/AdminUserControllerIntegrationTest.java
+++ b/backend/src/test/java/com/univoyage/admin/user/controller/AdminUserControllerIntegrationTest.java
@@ -123,10 +123,10 @@ class AdminUserControllerIntegrationTest {
   }
 
   private UserEntity findOrCreateHeadAdmin() {
-    return userRepository.findByEmail(SEEDED_HEAD_ADMIN_EMAIL).orElseGet(() -> userRepository
-        .save(UserEntity.builder().name("Papa").surname("Volarić").email(SEEDED_HEAD_ADMIN_EMAIL)
-            .passwordHash("{noop}unused").dateOfRegister(Instant.now()).role(Role.HEAD_ADMIN)
-            .build()));
+    return userRepository.findByEmail(SEEDED_HEAD_ADMIN_EMAIL)
+        .orElseGet(() -> userRepository.save(UserEntity.builder().name("Papa").surname("Volarić")
+            .email(SEEDED_HEAD_ADMIN_EMAIL).passwordHash("{noop}unused")
+            .dateOfRegister(Instant.now()).role(Role.HEAD_ADMIN).build()));
   }
 
   private UserEntity saveUser(String email, Role role) {

--- a/backend/src/test/java/com/univoyage/admin/user/controller/AdminUserControllerIntegrationTest.java
+++ b/backend/src/test/java/com/univoyage/admin/user/controller/AdminUserControllerIntegrationTest.java
@@ -83,9 +83,7 @@ class AdminUserControllerIntegrationTest {
   @Test
   @DisplayName("PATCH /api/admin/users/{id}/role returns 400 when role is missing")
   void updateRole_validationFails() throws Exception {
-    UserEntity headAdmin = userRepository.findByEmail(SEEDED_HEAD_ADMIN_EMAIL)
-        .orElseThrow(() -> new IllegalStateException(
-            "Seed HEAD_ADMIN user required: " + SEEDED_HEAD_ADMIN_EMAIL));
+    UserEntity headAdmin = findOrCreateHeadAdmin();
     UserEntity target = saveUser("admin-role-val@example.com", Role.USER);
 
     mockMvc
@@ -98,9 +96,7 @@ class AdminUserControllerIntegrationTest {
   @Test
   @DisplayName("PATCH /api/admin/users/{id}/role promotes USER to ADMIN when HEAD_ADMIN acts")
   void updateRole_headAdminPromotesUser() throws Exception {
-    UserEntity headAdmin = userRepository.findByEmail(SEEDED_HEAD_ADMIN_EMAIL)
-        .orElseThrow(() -> new IllegalStateException(
-            "Seed HEAD_ADMIN user required: " + SEEDED_HEAD_ADMIN_EMAIL));
+    UserEntity headAdmin = findOrCreateHeadAdmin();
     UserEntity target = saveUser("admin-promote@example.com", Role.USER);
 
     mockMvc
@@ -124,6 +120,13 @@ class AdminUserControllerIntegrationTest {
       request.setAttribute(JwtAuthenticationFilter.TFA_REQUEST_ATTRIBUTE, Boolean.TRUE);
       return request;
     };
+  }
+
+  private UserEntity findOrCreateHeadAdmin() {
+    return userRepository.findByEmail(SEEDED_HEAD_ADMIN_EMAIL).orElseGet(() -> userRepository
+        .save(UserEntity.builder().name("Papa").surname("Volarić").email(SEEDED_HEAD_ADMIN_EMAIL)
+            .passwordHash("{noop}unused").dateOfRegister(Instant.now()).role(Role.HEAD_ADMIN)
+            .build()));
   }
 
   private UserEntity saveUser(String email, Role role) {

--- a/backend/src/test/java/com/univoyage/auth/controller/SecurityIntegrationTest.java
+++ b/backend/src/test/java/com/univoyage/auth/controller/SecurityIntegrationTest.java
@@ -218,6 +218,13 @@ class SecurityIntegrationTest {
         .andExpect(status().isBadRequest());
   }
 
+  @Test
+  @DisplayName("POST /api/contact without auth is not blocked with 401 (permitAll)")
+  void contact_notUnauthorizedWithoutToken() throws Exception {
+    mockMvc.perform(post("/api/contact").contentType(MediaType.APPLICATION_JSON).content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
   private UserEntity persistPlainUser(String email) {
     return userRepository.save(UserEntity.builder().name("Security").surname("User").email(email)
         .passwordHash("{noop}unused").dateOfRegister(Instant.now()).role(Role.USER).build());

--- a/backend/src/test/java/com/univoyage/auth/security/PublicApiRequestMatcherTest.java
+++ b/backend/src/test/java/com/univoyage/auth/security/PublicApiRequestMatcherTest.java
@@ -19,7 +19,7 @@ class PublicApiRequestMatcherTest {
 
   @ParameterizedTest(name = "skip {0} {1}")
   @CsvSource({"/api/auth/login,POST,true", "/api/auth/google/callback,POST,true",
-      "/api/quiz/recommend,POST,true", "/api/destinations,GET,true",
+      "/api/quiz/recommend,POST,true", "/api/contact,POST,true", "/api/destinations,GET,true",
       "/api/destinations/1/reviews,GET,true", "/api/reference/countries,GET,true",
       "/actuator/health,GET,true", "/api/admin/destinations,GET,false",
       "/api/admin/destinations,POST,false", "/api/destinations,POST,false", "/api/trips,GET,false",

--- a/backend/src/test/java/com/univoyage/contact/controller/ContactControllerIntegrationTest.java
+++ b/backend/src/test/java/com/univoyage/contact/controller/ContactControllerIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.univoyage.contact.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class ContactControllerIntegrationTest {
+
+  private static final String VALID_BODY = """
+      {
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+        "subject": "Trip planning question",
+        "message": "I would like to know more about student travel options in Europe."
+      }
+      """;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("POST /api/contact accepts valid payload and returns reference id")
+  void submitContactForm_success() throws Exception {
+    mockMvc
+        .perform(post("/api/contact").contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+        .andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.message")
+            .value("Thank you for reaching out! We'll get back to you within 24-48 hours."))
+        .andExpect(jsonPath("$.data.referenceId").value(matchesPattern("[A-F0-9]{8}")));
+  }
+
+  @Test
+  @DisplayName("POST /api/contact returns 400 when required fields are missing")
+  void submitContactForm_missingFields() throws Exception {
+    mockMvc
+        .perform(post("/api/contact").contentType(MediaType.APPLICATION_JSON)
+            .content("{\"email\":\"jane@example.com\"}"))
+        .andExpect(status().isBadRequest()).andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.error").value("Validation failed for the request payload."))
+        .andExpect(jsonPath("$.data.name").exists());
+  }
+
+  @Test
+  @DisplayName("POST /api/contact returns 400 for invalid email")
+  void submitContactForm_invalidEmail() throws Exception {
+    mockMvc.perform(post("/api/contact").contentType(MediaType.APPLICATION_JSON).content("""
+        {
+          "name": "Jane Doe",
+          "email": "not-an-email",
+          "subject": "Hello",
+          "message": "This message is long enough for validation."
+        }
+        """)).andExpect(status().isBadRequest()).andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.data.email").exists());
+  }
+
+  @Test
+  @DisplayName("POST /api/contact returns 400 when message is too short")
+  void submitContactForm_messageTooShort() throws Exception {
+    mockMvc.perform(post("/api/contact").contentType(MediaType.APPLICATION_JSON).content("""
+        {
+          "name": "Jane Doe",
+          "email": "jane@example.com",
+          "subject": "Hello",
+          "message": "short"
+        }
+        """)).andExpect(status().isBadRequest()).andExpect(jsonPath("$.success").value(false))
+        .andExpect(jsonPath("$.data.message").exists());
+  }
+
+  @Test
+  @DisplayName("POST /api/contact returns 400 for malformed JSON")
+  void submitContactForm_malformedJson() throws Exception {
+    mockMvc
+        .perform(post("/api/contact").contentType(MediaType.APPLICATION_JSON).content("{bad json"))
+        .andExpect(status().isBadRequest()).andExpect(jsonPath("$.success").value(false));
+  }
+}

--- a/backend/src/test/java/com/univoyage/contact/controller/ContactRateLimitIntegrationTest.java
+++ b/backend/src/test/java/com/univoyage/contact/controller/ContactRateLimitIntegrationTest.java
@@ -1,0 +1,72 @@
+package com.univoyage.contact.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {"app.contact.ip-max-attempts=2", "app.contact.ip-window=PT1H"})
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class ContactRateLimitIntegrationTest {
+
+  private static final String VALID_BODY = """
+      {
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+        "subject": "Rate limit test",
+        "message": "Checking contact form IP rate limiting behaviour."
+      }
+      """;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("POST /api/contact returns 429 when IP exceeds configured window limit")
+  void contactFormRateLimitedByIp() throws Exception {
+    mockMvc
+        .perform(post("/api/contact").contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(post("/api/contact").contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(post("/api/contact").contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+        .andExpect(status().isTooManyRequests()).andExpect(header().exists("Retry-After"))
+        .andExpect(jsonPath("$.success").value(false)).andExpect(
+            jsonPath("$.error").value("Too many contact submissions. Please try again later."));
+  }
+
+  @Test
+  @DisplayName("X-Forwarded-For first hop is rate-limited separately per client IP")
+  void rateLimitUsesXForwardedForWhenPresent() throws Exception {
+    for (int i = 0; i < 2; i++) {
+      mockMvc
+          .perform(post("/api/contact").header("X-Forwarded-For", "203.0.113.10")
+              .contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+          .andExpect(status().isOk());
+    }
+
+    mockMvc
+        .perform(post("/api/contact").header("X-Forwarded-For", "203.0.113.10")
+            .contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+        .andExpect(status().isTooManyRequests());
+
+    mockMvc
+        .perform(post("/api/contact").header("X-Forwarded-For", "203.0.113.20")
+            .contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+        .andExpect(status().isOk());
+  }
+}


### PR DESCRIPTION
## Summary

- Add POST `/api/contact` endpoint with Jakarta Bean Validation for contact form submissions
- Implement IP-based rate limiting (5 requests per 15 min) to prevent spam
- Register endpoint as public in SecurityConfiguration and PublicApiRequestMatcher

Closes #295

## Changes

- `ContactRequest` DTO with validation (name, email, subject, message)
- `ContactResponse` DTO with confirmation message and reference ID
- `ContactService` that processes and logs submissions
- `ContactIpRateLimiter` using existing FixedWindowIpRateLimiter infrastructure
- `ContactLimitProperties` for configurable rate-limit settings
- Security config updated to allow unauthenticated access to `/api/contact`

Made with [Cursor](https://cursor.com)